### PR TITLE
Fix comment on the same line as a volume statement being invalid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM goacme/lego:v4.16.1
 
-VOLUME /.lego # Save certs and account to external volume
+# Save certs and account to external volume
+VOLUME /.lego 
 
 COPY app/crontab /var/spool/cron/crontabs/root
 RUN chown -R root:root /var/spool/cron/crontabs/root


### PR DESCRIPTION
When using the image as described in the README, doing a `docker compose up -d` a second time would error with
```
Error response from daemon: invalid mount config for type "volume": invalid mount path: 'Save' mount path must be absolute
```
Or any other word from the "comment" as the path (Save, certs, and, account, to, external, and volume)

Dockerfile [comments](https://docs.docker.com/reference/dockerfile/#format) cannot be on the same line as a statement